### PR TITLE
Render and display tutorials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,11 @@ jobs:
           export PYVISTA_OFF_SCREEN=true
           Xvfb $DISPLAY -screen 0 1024x768x24 > /dev/null 2>&1 &
           sleep 3
-          python3 -m pytest --nbval tutorials/01-*.ipynb
+          python3 -m pytest --nbval tutorials/{01..05}-*.ipynb
       - name: Convert notebooks
         run: |
           . /home/firedrake/firedrake/bin/activate
-          python3 -m jupyter nbconvert --to notebook --execute --output-dir=rendered tutorials/01-*.ipynb
+          python3 -m jupyter nbconvert --to notebook --execute --output-dir=rendered tutorials/{01..05}-*.ipynb
       - uses: actions/upload-artifact@v4
         with:
           name: notebooks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,48 @@ permissions:
   id-token: write
 
 jobs:
+  render:
+    runs-on: self-hosted
+    container:
+      image: firedrakeproject/firedrake:latest
+      options: --shm-size 2g
+
+    env:
+      OMP_NUM_THREADS: 1
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: g-adopt/tutorials
+          ref: angus-g/website-deploy
+          path: tutorials
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libgl1-mesa-glx xvfb
+          . /home/firedrake/firedrake/bin/activate
+          python3 -m pip install nbval pyvista nbconvert
+          python3 -m pip install gadopt[optimisation]
+      - name: Run test
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          export DISPLAY=:99
+          export PYVISTA_OFF_SCREEN=true
+          Xvfb $DISPLAY -screen 0 1024x768x24 > /dev/null 2>&1 &
+          sleep 3
+          python3 -m pytest --nbval tutorials/01-*.ipynb
+      - name: Convert notebooks
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          python3 -m jupyter nbconvert --to notebook --execute --output-dir=rendered tutorials/01-*.ipynb
+      - uses: actions/upload-artifact@v4
+        with:
+          name: notebooks
+          path: rendered
+
   build:
     runs-on: ubuntu-latest
+    needs: render
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -23,6 +63,10 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
+      - uses: actions/download-artifact@v4
+        with:
+          name: notebooks
+          path: docs/tutorials
       - name: Build site
         run: |
           mkdocs build --clean

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,0 +1,3 @@
+# Tutorials
+
+These are a list of tutorials, gradually introducing the G-ADOPT library.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,11 +9,16 @@ theme:
   features:
     - navigation.tabs
     - toc.integrate
+plugins:
+  - mkdocs-jupyter:
+      toc_depth: 2
 nav:
   - Home: index.md
   - Install: install.md
   - Documentation: documentation.md
-  - Tutorials: tutorials.md
+  - Tutorials:
+    - tutorials.md
+    - Helmholtz: tutorials/01-spd-helmholtz.nbconvert.ipynb
   - Benchmarks: benchmarks.md
   - Team: team.md
   - Funding: funding.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,10 @@ nav:
   - Tutorials:
     - tutorials.md
     - Helmholtz: tutorials/01-spd-helmholtz.ipynb
+    - Poisson: tutorials/02-poisson.ipynb
+    - Elasticity: tutorials/03-elasticity.ipynb
+    - "Burgers' Equation": tutorials/04-burgers.ipynb
+    - PDE Constrained Optimisation: tutorials/05-pde-constrained-optimisation.ipynb
   - Benchmarks: benchmarks.md
   - Team: team.md
   - Funding: funding.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ nav:
   - Documentation: documentation.md
   - Tutorials:
     - tutorials.md
-    - Helmholtz: tutorials/01-spd-helmholtz.nbconvert.ipynb
+    - Helmholtz: tutorials/01-spd-helmholtz.ipynb
   - Benchmarks: benchmarks.md
   - Team: team.md
   - Funding: funding.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs~=1.5.3
 mkdocs-material~=9.5.8
-mkdocs-jupyter~=0.24.6
+https://github.com/angus-g/mkdocs-jupyter/releases/download/0.24.7/mkdocs_jupyter-0.24.6-py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs~=1.5.3
 mkdocs-material~=9.5.8
+mkdocs-jupyter~=0.24.6


### PR DESCRIPTION
This branch will render and display tutorials from the https://github.com/g-adopt/tutorials repository. For development, I've set up the `build.yml` action to pull from the branch behind this pull request, which is where the changes to the tutorials should probably end up: https://github.com/g-adopt/tutorials/pull/3.

## Deployment
The *pull* model of incorporating the tutorials definitely isn't how things should be done for the actual deployment! I think I'll set up a time-based (weekly, or similar) Action on the tutorials repository that will run the notebooks and upload the versions with populated plots/outputs as an artifact. Then the build step of the website can just grab the latest build artifact and include that, without requiring a separate build step (which takes ages when the geodynamics notebooks are included...)

## Development
For local development/testing of the notebooks' functionality and formatting, there are a couple of steps.

1. Check out the branch for this PR `angus-g/tutorials`
2. **In your MkDocs virtual environment**: re-install the project dependencies: `python3 -m pip install -r requirements.txt`
3. The *rendered* notebooks need to be placed in the `docs/tutorials/` directory

To actually render the notebooks, you can install the `nbconvert` package, and run

    python3 -m jupyter nbconvert --to notebook --execute --output-dir=<g-adopt.github.io>/docs/tutorials <notebook>.ipynb

To start with, I've included the first 5 tutorials (up to PDE Constrained Optimisation). To include further tutorials, you'll need to add them into `mkdocs.yml` in the `nav` section (the file should be a pretty good guide for the required format).

### Note
As always, don't forget to clear the outputs of the notebooks before committing them to the tutorials repository!