### PR TITLE
Add a BibBase publications list

### DIFF
--- a/docs/publications.md
+++ b/docs/publications.md
@@ -15,13 +15,3 @@ Please also cite Firedrake using the instructions [here](https://www.firedrakepr
 ## Journal papers and conference proceedings about G-ADOPT
 
 <script src="https://bibbase.org/show?bib=https://bibbase.org/network/files/zhofWTSihyTEbzR8W&jsonp=1"></script>
-
-
-<!---
-Add the below in when we have some applications...
-
-## Journal papers and conference proceedings using G-ADOPT
-
-<script src="https://bibbase.org/show?bib=https://bibbase.org/network/files/xiRp977Pw7zBtg5Ma&jsonp=1"></script>
-
---->

--- a/docs/publications.md
+++ b/docs/publications.md
@@ -4,43 +4,10 @@
 
 If you publish results using G-ADOPT, we would be grateful if you would cite the software using the following metadata and the two articles below.
 
-<details markdown>
-        
-<summary> G-ADOPT references (BibTeX) </summary>
-
-    author = {Davies, D. Rhodri and Ghelichkhan, Siavash and Gibson, Angus H. and Kramer, Stephan C. and Duvernay, Thomas and Scott, Will and Hoggard, Mark and Ham, David A. and Turner, Ruby},
-    doi = {https://zenodo.org/doi/10.5281/zenodo.5644391},
-    month = feb,
-    title = {{G-ADOPT}},
-    url = {https://github.com/g-adopt/g-adopt},
-    version = {2.2.0},
-    year = {2024}
-    }
-    
-    @Article{Davies_Towards_2022,
-    AUTHOR = {Davies, D. R. and Kramer, S. C. and Ghelichkhan, S. and Gibson, A.},
-    TITLE = {Towards automatic finite-element methods for geodynamics via Firedrake},
-    JOURNAL = {Geoscientific Model Development},
-    VOLUME = {15},
-    YEAR = {2022},
-    NUMBER = {13},
-    PAGES = {5127--5166},
-    URL = {https://gmd.copernicus.org/articles/15/5127/2022/},
-    DOI = {10.5194/gmd-15-5127-2022}
-    }
-    
-    @Article{Ghelichkhan_Automatic_2024,
-    AUTHOR = {Ghelichkhan, S. and Gibson, A. and Davies, D. R. and Kramer, S. C. and Ham, D. A.},
-    TITLE = {Automatic adjoint-based inversion schemes for geodynamics: Reconstructing the evolution of Earth’s mantle in space and time},
-    JOURNAL = {EGUsphere},
-    VOLUME = {2023},
-    YEAR = {2023},
-    PAGES = {1--46},
-    URL = {https://egusphere.copernicus.org/preprints/2023/egusphere-2023-2683/},
-    DOI = {10.5194/egusphere-2023-2683}
-    }
-</details>
-
+??? abstract "G-ADOPT references (BibTeX)"
+    ``` bibtex title="gadopt.bib"
+    --8<-- "gadopt.bib"
+    ```
 
 Please also cite Firedrake using the instructions [here](https://www.firedrakeproject.org/citing.html).
 

--- a/docs/publications.md
+++ b/docs/publications.md
@@ -1,1 +1,60 @@
 # Publications
+
+## Citing G-ADOPT 
+
+If you publish results using G-ADOPT, we would be grateful if you would cite the software using the following metadata and the two articles below.
+
+<details markdown>
+        
+<summary> G-ADOPT references (BibTeX) </summary>
+
+    author = {Davies, D. Rhodri and Ghelichkhan, Siavash and Gibson, Angus H. and Kramer, Stephan C. and Duvernay, Thomas and Scott, Will and Hoggard, Mark and Ham, David A. and Turner, Ruby},
+    doi = {https://zenodo.org/doi/10.5281/zenodo.5644391},
+    month = feb,
+    title = {{G-ADOPT}},
+    url = {https://github.com/g-adopt/g-adopt},
+    version = {2.2.0},
+    year = {2024}
+    }
+    
+    @Article{Davies_Towards_2022,
+    AUTHOR = {Davies, D. R. and Kramer, S. C. and Ghelichkhan, S. and Gibson, A.},
+    TITLE = {Towards automatic finite-element methods for geodynamics via Firedrake},
+    JOURNAL = {Geoscientific Model Development},
+    VOLUME = {15},
+    YEAR = {2022},
+    NUMBER = {13},
+    PAGES = {5127--5166},
+    URL = {https://gmd.copernicus.org/articles/15/5127/2022/},
+    DOI = {10.5194/gmd-15-5127-2022}
+    }
+    
+    @Article{Ghelichkhan_Automatic_2024,
+    AUTHOR = {Ghelichkhan, S. and Gibson, A. and Davies, D. R. and Kramer, S. C. and Ham, D. A.},
+    TITLE = {Automatic adjoint-based inversion schemes for geodynamics: Reconstructing the evolution of Earth’s mantle in space and time},
+    JOURNAL = {EGUsphere},
+    VOLUME = {2023},
+    YEAR = {2023},
+    PAGES = {1--46},
+    URL = {https://egusphere.copernicus.org/preprints/2023/egusphere-2023-2683/},
+    DOI = {10.5194/egusphere-2023-2683}
+    }
+</details>
+
+
+Please also cite Firedrake using the instructions [here](https://www.firedrakeproject.org/citing.html).
+
+
+## Journal papers and conference proceedings about G-ADOPT
+
+<script src="https://bibbase.org/show?bib=https://bibbase.org/network/files/zhofWTSihyTEbzR8W&jsonp=1"></script>
+
+
+<!---
+Add the below in when we have some applications...
+
+## Journal papers and conference proceedings using G-ADOPT
+
+<script src="https://bibbase.org/show?bib=https://bibbase.org/network/files/xiRp977Pw7zBtg5Ma&jsonp=1"></script>
+
+--->

--- a/gadopt.bib
+++ b/gadopt.bib
@@ -1,0 +1,32 @@
+@software{Davies_G-ADOPT_2024,
+author = {Davies, D. Rhodri and Ghelichkhan, Siavash and Gibson, Angus H. and Kramer, Stephan C. and Duvernay, Thomas and Scott, Will and Hoggard, Mark and Ham, David A. and Turner, Ruby},
+doi = {https://zenodo.org/doi/10.5281/zenodo.5644391},
+month = feb,
+title = {{G-ADOPT}},
+url = {https://github.com/g-adopt/g-adopt},
+version = {2.2.0},
+year = {2024}
+}
+
+@Article{Davies_Towards_2022,
+AUTHOR = {Davies, D. R. and Kramer, S. C. and Ghelichkhan, S. and Gibson, A.},
+TITLE = {Towards automatic finite-element methods for geodynamics via Firedrake},
+JOURNAL = {Geoscientific Model Development},
+VOLUME = {15},
+YEAR = {2022},
+NUMBER = {13},
+PAGES = {5127--5166},
+URL = {https://gmd.copernicus.org/articles/15/5127/2022/},
+DOI = {10.5194/gmd-15-5127-2022}
+}
+
+@Article{Ghelichkhan_Automatic_2024,
+AUTHOR = {Ghelichkhan, S. and Gibson, A. and Davies, D. R. and Kramer, S. C. and Ham, D. A.},
+TITLE = {Automatic adjoint-based inversion schemes for geodynamics: Reconstructing the evolution of Earth’s mantle in space and time},
+JOURNAL = {EGUsphere},
+VOLUME = {2023},
+YEAR = {2023},
+PAGES = {1--46},
+URL = {https://egusphere.copernicus.org/preprints/2023/egusphere-2023-2683/},
+DOI = {10.5194/egusphere-2023-2683}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,3 +26,6 @@ nav:
   - Funding: funding.md
   - Events: events.md
   - Publications: publications.md
+
+markdown_extensions:
+  - md_in_html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,11 +7,16 @@ theme:
   icon:
     repo: fontawesome/brands/github
   features:
+    - content.code.copy
     - navigation.tabs
     - toc.integrate
 markdown_extensions:
+  - admonition
   - attr_list
   - md_in_html
+  - pymdownx.details
+  - pymdownx.snippets
+  - pymdownx.superfences
   - toc:
       toc_depth: 3
 extra_css:
@@ -26,6 +31,3 @@ nav:
   - Funding: funding.md
   - Events: events.md
   - Publications: publications.md
-
-markdown_extensions:
-  - md_in_html


### PR DESCRIPTION
Based on Firedrake. web based solution at BibBase.org that stores a .bib file and generates a nice interface for the references. I've made a free account and uploaded the bibliography there. I think you would need to update the bib file manually on the website to change the reference list. Probably more useful when we have more papers!

Also there is a slightly weird feature in that it wants to try and identify who is the 'owner' of the bibbase page. It seems like there is some algorithm where it thinks that if there is one person who is on the majority / all of the publications it will automatically assign the page to them... at the moment Rhodri's name has become a hyperlink to the same page... (and if you remove rhodri's name it updates to someone else...)

e.g. see here https://bibbase.userecho.com/communities/1/topics/60-authors-names-are-clickable-links