### PR TITLE
Update bib entry for software

### DIFF
--- a/gadopt.bib
+++ b/gadopt.bib
@@ -1,10 +1,10 @@
-@software{Davies_G-ADOPT_2024,
-author = {Davies, D. Rhodri and Ghelichkhan, Siavash and Gibson, Angus H. and Kramer, Stephan C. and Duvernay, Thomas and Scott, Will and Hoggard, Mark and Ham, David A. and Turner, Ruby},
-doi = {https://zenodo.org/doi/10.5281/zenodo.5644391},
+@software{Gibson_G-ADOPT_2024,
+author = {Gibson, Angus and Davies, Rhodri and Kramer, Stephan and Ghelichkhan, Sia and Turner, Ruby and Duvernay, Thomas and Scott, Will},
+doi = {10.5281/zenodo.5644391},
 month = feb,
 title = {{G-ADOPT}},
 url = {https://github.com/g-adopt/g-adopt},
-version = {2.2.0},
+version = {v2.2.0},
 year = {2024}
 }
 


### PR DESCRIPTION
Very small change to bib software entry based on using get_software_citation.py in #55 from citation2
so only the people tagged on Zenodo are included in the build 