### PR TITLE
Style BibBase author link as normal text

### DIFF
--- a/docs/stylesheets/gadopt.css
+++ b/docs/stylesheets/gadopt.css
@@ -35,3 +35,8 @@ figure.bio {
     border-radius: 5rem;
     width: 10rem;
 }
+
+.bibbase.author.link {
+    color: inherit;
+    pointer-events: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,7 @@ markdown_extensions:
   - toc:
       toc_depth: 3
 extra_css:
-  - stylesheets/team.css
+  - stylesheets/gadopt.css
 nav:
   - Home: index.md
   - Install: install.md


### PR DESCRIPTION
Fixes the concern raised in https://github.com/g-adopt/g-adopt.github.io/pull/5#issue-2131080329