### PR TITLE
Add workshop registration page

### DIFF
--- a/docs/events/workshops/posts/2024-workshop.md
+++ b/docs/events/workshops/posts/2024-workshop.md
@@ -13,6 +13,7 @@ The workshop will provide background to the platform and training for potential 
 3. Multi-material simulations.
 4. Adjoint-based optimisation problems.
 
-Thanks to generous support from our partners at [AuScope](https://www.auscope.org.au/), this workshop will be free for all students and early career academics.
+Thanks to generous support from our partners at [AuScope](https://www.auscope.org.au/), this workshop will be free for all students and early career academics, provided registration is complete before the **early-bird registration deadline of 30/06/2024**. Student and early-career registrations after this date require a contribution of $50. Registration for other participants will be $200 prior to the early-bird registration deadline, and $250 thereafter. 
 
-Further details on registration will be provided in due course. 
+## [Register Here](https://payments.anu.edu.au/GADOPT2024)
+

--- a/docs/events/workshops/posts/2024-workshop.md
+++ b/docs/events/workshops/posts/2024-workshop.md
@@ -4,7 +4,7 @@ date: 2024-02-13
 
 # G-ADOPT Workshop 2024
 
-The 2024 G-ADOPT workshop will be held at the [ANU's Kioloa Coastal Campus](https://www.anu.edu.au/about/campuses-facilities/kioloa-coastal-campus) on the New South Wales coast. Mark your diaries for Sunday 10/11/24 - Tuesday 12/11/24. 
+The 2024 G-ADOPT workshop will be held at the [ANU's Kioloa Coastal Campus](https://www.anu.edu.au/about/campuses-facilities/kioloa-coastal-campus) on the New South Wales coast. Mark your diaries for **Sunday 10/11/24 (4 pm) - Tuesday 12/11/24 (4 pm)**. 
 
 The workshop will provide background to the platform and training for potential users, thus facilitating community growth. We welcome national and international participants. The workshop will provide an opportunity for the G-ADOPT team to showcase recent progress on the forward and adjoint components of this finite element modelling platform. Key areas of focus will include:
 


### PR DESCRIPTION
Add a link to the xetta page for workshop registration and a little more information on timing. 

@angus-g - could you have a quick peek, and also perhaps do some magic such that the "Register Here" link stands out more? Is it work also adding this link to the "announcements" headline, or not?