### PR TITLE
Render API documentation directly out of g-adopt repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
+      - name: Clone G-ADOPT for API documentation
+        uses: actions/checkout@v4
+        with:
+          repository: g-adopt/g-adopt
+          path: g-adopt
       - name: Build site
         run: |
           mkdocs build --clean

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,6 +1,9 @@
 ::: gadopt.approximations
     options:
       show_source: false
+      filters: ["!BaseApproximation"]
+
+::: gadopt.diagnostics
 
 ::: gadopt.energy_solver
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,4 +1,6 @@
 ::: gadopt.approximations
+    options:
+      show_source: false
 
 ::: gadopt.energy_solver
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,7 @@
+::: gadopt.approximations
+
+::: gadopt.energy_solver
+
+::: gadopt.stokes_integrators
+
+::: gadopt.time_stepper

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,15 @@ plugins:
       post_readtime: false
       archive: false
   - glightbox
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [g-adopt]
+          options:
+            show_root_heading: true
+            show_root_full_path: false
+            docstring_style: google
+            merge_init_into_class: true
 nav:
   - Home:
       - index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,9 @@ plugins:
             show_root_full_path: false
             docstring_style: google
             merge_init_into_class: true
+            members_order: source
+          import:
+            - https://fenics.readthedocs.io/projects/ufl/en/latest/objects.inv
 nav:
   - Home:
       - index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs~=1.5.3
 mkdocs-material~=9.5.8
 mkdocs-glightbox~=0.3.7
+mkdocstrings[python]~=0.24.0


### PR DESCRIPTION
Maybe we should be a bit more specific about what we render (e.g. time stepping methods)? There's still a bit of scope for stuff like better intra-doc linking, but this is probably fine as a first step.