### PR TITLE
Remove downgrade hack for mesa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,9 @@ jobs:
         with:
           repository: g-adopt/g-adopt
           path: tutorials
-      - name: Make previous version of Mesa available
-        run: |
-          sed 's/noble/mantic/g' /etc/apt/sources.list.d/ubuntu.sources | sudo tee /etc/apt/sources.list.d/mantic.sources > /dev/null
-          sudo apt update
-          sudo apt remove -y libx11-6
-          sudo apt -t mantic install -y --allow-downgrades libglx-mesa0=23.2.1-1ubuntu3.1 libglapi-mesa=23.2.1-1ubuntu3.1 libgl1-mesa-dri=23.2.1-1ubuntu3.1 libx11-6=2:1.8.6-1ubuntu1
       - name: Install dependencies
         run: |
+          sudo apt update
           sudo apt install -y xvfb gmsh
           . /home/firedrake/firedrake/bin/activate
           python3 -m pip install nbval nbconvert jupytext
@@ -44,6 +39,7 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           export DISPLAY=:99
           export PYVISTA_OFF_SCREEN=true
+          export LIBGL_ALWAYS_SOFTWARE=true
           Xvfb $DISPLAY -screen 0 1024x768x24 > /dev/null 2>&1 &
           sleep 3
           make -j -C tutorials convert_demos


### PR DESCRIPTION
We should just force software rendering, which also disables Zink and avoids an error message with xvfb.