### PR TITLE
Usability changes for notebooks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ plugins:
   - mkdocs-jupyter:
       toc_depth: 2
       custom_mathjax_url: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe"
+      include_source: True
   - gen-files:
       scripts:
         - scripts/gen_api_pages.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,10 +34,11 @@ markdown_extensions:
       toc_depth: 3
 extra_css:
   - stylesheets/gadopt.css
-extra_javascript:
-  - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://unpkg.com/mathjax@3/es5/startup.js
+extra:
+  mathjax:
+    - javascripts/mathjax.js
+    - https://polyfill.io/v3/polyfill.min.js?features=es6
+    - https://unpkg.com/mathjax@3/es5/startup.js
 plugins:
   - blog:
       blog_dir: events/workshops

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,3 +8,11 @@
 {% endif %}
 {{ super() }}
 {% endblock content %}
+{% block scripts %}
+{{ super() }}
+{% if not "tutorials" in page.url %}
+{% for script in config.extra.mathjax %}
+{{ script | script_tag }}
+{% endfor %}
+{% endif %}
+{% endblock scripts %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,3 +2,9 @@
 {% block announce %}
 <a href="/events/workshops/2024/02/13/g-adopt-workshop-2024/">2024 G-ADOPT Workshop</a>: 10-12 November 2024 at the ANU's Kioloa Coastal Campus
 {% endblock %}
+{% block content %}
+{% if page.nb_url %}
+<a href="{{ page.nb_url }}" title="Download notebook" class="md-content__button md-icon">{% include ".icons/material/download.svg" %}</a>
+{% endif %}
+{{ super() }}
+{% endblock content %}


### PR DESCRIPTION
Two things: we add a download button to tutorial pages to grab the notebook itself, in case people want to experiment with that directly (maybe useful for e.g. Colab)

![image](https://github.com/user-attachments/assets/9ae87045-fb0d-4f80-8ab1-cd164cc04020)

Second, I've fiddled around with how Javascript is included on pages so that the tutorials don't load the main mathjax javascript. This should mean that the math always renders correctly on the tutorials, instead of being a bit random depending on which script "wins" the loading race.