### PR TITLE
Interactive front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,9 @@ Areas of current application include:
 ---
 
 <figure markdown>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/i7MVDvISByk?si=GBXUxCCr6v5Feyd6" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="800" height="315" frameBorder="0" src="static/viewer.html"></iframe>
 <figcaption markdown>
-Thermal structure predicted from a global mantle convection simulation in G-ADOPT that incorporates 230 Myr of plate motion history reconstructed in [GPlates](https://www.gplates.org/). Each image includes a background cross-section, a radial surface immediately above the core-mantle boundary, and transparent isosurfaces at temperature anomalies (i.e. away from the radial average) of T=-0.075 (blue) and T=0.075 (red), highlighting the location of downwelling slabs and upwelling mantle plumes, respectively. Continental boundaries provide a geographic reference. The animation presents an Africa-centered view.
+Present-day thermal structure predicted from a global mantle convection simulation in G-ADOPT that incorporates 230 Myr of plate motion history reconstructed in [GPlates](https://www.gplates.org/). This interactive animation includes a background cross-section, a radial surface immediately above the core-mantle boundary, and isosurfaces at temperature anomalies (i.e. away from the radial average) of T=-0.075 (blue) and T=0.075 (red), highlighting the location of downwelling slabs and upwelling mantle plumes, respectively. Continental boundaries provide a geographic reference.
 </figcaption>
 </figure>
 

--- a/docs/javascripts/httpsceneviewer.js
+++ b/docs/javascripts/httpsceneviewer.js
@@ -1,0 +1,84 @@
+const vtkjs = window.vtkjs;
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer =
+  vtk.Rendering.Misc.vtkFullScreenRenderWindow.newInstance();
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+
+// ----------------------------------------------------------------------------
+// Example code
+// ----------------------------------------------------------------------------
+const controlPanel = `
+<button id="btn">Play/Pause</button>
+`;
+
+function initialiseAnim(nextStep) {
+  let interval = setInterval(nextStep,100);
+  const select = document.getElementById('btn');
+  select.addEventListener('click', () => {
+    if ( interval == null ) {
+      interval = setInterval(nextStep,100);
+    } else {
+      clearInterval(interval);
+      interval = null;
+    }
+  });
+};
+
+function downloadZipFile(url) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.onreadystatechange = (e) => {
+      if (xhr.readyState === 4) {
+        if (xhr.status === 200 || xhr.status === 0) {
+          resolve(xhr.response);
+        } else {
+          reject(xhr, e);
+        }
+      }
+    };
+
+    // Make request
+    xhr.open("GET", url, true);
+    xhr.responseType = "arraybuffer";
+    xhr.send();
+  });
+}
+
+downloadZipFile("https://data.gadopt.org/website/frontpage_model.vtkjs").then((zipContent) => {
+  const dataAccessHelper = vtk.IO.Core.DataAccessHelper.get("zip", {
+    zipContent,
+    callback() {
+      const sceneImporter = vtk.IO.Core.vtkHttpSceneLoader.newInstance({
+        dataAccessHelper,
+        renderer,
+      });
+
+      sceneImporter.setUrl("index.json");
+      sceneImporter.onReady(() => {
+        const animationHandler = sceneImporter.getAnimationHandler();
+        if (animationHandler && animationHandler.getTimeSteps().length > 1) {
+          const steps = animationHandler.getTimeSteps();
+          const nextStep = () => {
+            global_step =
+              (global_step + 1) % animationHandler.getTimeSteps().length;
+            const step = steps[global_step];
+            animationHandler.setCurrentTimeStep(step);
+            renderer.resetCameraClippingRange();
+            renderWindow.render();
+          };
+          initialiseAnim(nextStep)
+        }
+        renderWindow.render();
+      });
+    },
+  });
+});
+
+var global_step = 0;
+fullScreenRenderer.addController(controlPanel);

--- a/docs/static/viewer.html
+++ b/docs/static/viewer.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,height=device-height,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"
+    />
+    <script src="https://unpkg.com/vtk.js@32.8.0/vtk.js"></script>
+    <script src="https://unpkg.com/@babel/polyfill@7.0.0/dist/polyfill.js"></script>
+  </head>
+  <body>
+    <div class="content"></div>
+    <script defer="defer" src="../javascripts/httpsceneviewer.js"></script>
+  </body>
+</html>
+


### PR DESCRIPTION
Interactive model on the website front page. The model data is hosted on data.gadopt.org, which allows us to fine-tune and update the model as necessary outside of github. The `iframe` implementation is ugly but this is the method that Kitware themselves use on their examples pages: https://kitware.github.io/vtk-js/examples/. 