### PR TITLE
Add analytics to gadopt.org

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,9 @@ extra:
     - javascripts/mathjax.js
     - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://unpkg.com/mathjax@3/es5/startup.js
+  analytics:
+    provider: google
+    property: G-E8ZDKFN2BR
 plugins:
   - blog:
       blog_dir: events/workshops


### PR DESCRIPTION
Looks like this is built into mkdocs-material already, just have to set it up.